### PR TITLE
Change Go module name to github.com/tillitis/tkey-testapps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tillitis/tillitis-key1-apps
+module github.com/tillitis/tkey-testapps
 
 go 1.19
 


### PR DESCRIPTION
## Description

Just changes the Go module name that was apparently left from the old repo when extracting just the test apps.

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing

