### PR TITLE
Add USB controller test app that echos received data back to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Device apps:
   hardcoded message using the Monocypher function in tkey-libs.
   Outputs measurements in milliseconds in hex. Attach with picocom or
   similar. Start measurements by sending a character.
+- `usb_echo`: Test app for the USB controller. Received data is echoed
+  back to the same USB interface as from where it was received. Note:
+  The USB controller firmware has to support the multi-endpoint USB
+  controller protocol.
 
 See the [TKey Developer Handbook](https://dev.tillitis.se/) for how to
 develop your own apps, how to run and debug them in the emulator or on

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -26,6 +26,7 @@ path = [
      "apps/rng_stream/README.md",
      "apps/timer/Makefile",
      "apps/touch/Makefile",
+     "apps/usb_echo/Makefile",
      "system/60-tkey.rules",
      "test/requirements.txt"
 ]

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -1,11 +1,12 @@
 .PHONY: all
-all: signbench timer rng_stream blink nx touch
+all: signbench timer rng_stream blink nx touch usb_echo
 	$(MAKE) -C signbench
 	$(MAKE) -C timer
 	$(MAKE) -C rng_stream
 	$(MAKE) -C blink
 	$(MAKE) -C nx
 	$(MAKE) -C touch
+	$(MAKE) -C usb_echo
 
 .PHONY: checkfmt
 checkfmt:
@@ -14,6 +15,7 @@ checkfmt:
 	$(MAKE) -C rng_stream checkfmt
 	$(MAKE) -C timer checkfmt
 	$(MAKE) -C touch checkfmt
+	$(MAKE) -C usb_echo checkfmt
 
 .PHONY: clean
 clean:
@@ -23,3 +25,4 @@ clean:
 	$(MAKE) -C rng_stream clean
 	$(MAKE) -C timer clean
 	$(MAKE) -C touch clean
+	$(MAKE) -C usb_echo clean

--- a/apps/usb_echo/Makefile
+++ b/apps/usb_echo/Makefile
@@ -1,0 +1,51 @@
+OBJCOPY ?= llvm-objcopy
+
+P := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+LIBDIR ?= $(P)/../../../tkey-libs
+
+CC = clang
+
+INCLUDE=$(LIBDIR)/include
+
+CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany \
+   -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf \
+   -fno-builtin-putchar -nostdlib -mno-relax -flto -g \
+   -Wall -Werror=implicit-function-declaration \
+   -I $(INCLUDE) -I $(LIBDIR)
+
+AS = clang
+ASFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany -mno-relax
+
+LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR) -lcommon -lcrt0
+
+.PHONY: all
+all: app.bin
+
+# Turn elf into bin for device
+%.bin: %.elf
+	$(OBJCOPY) --input-target=elf32-littleriscv --output-target=binary $^ $@
+	chmod a-x $@
+
+show-hash: app.bin
+	shasum -a 512 app.bin
+
+# USB echo app
+OBJS =main.o
+app.elf: $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) -o $@
+$(OBJS): $(INCLUDE)/tkey/tk1_mem.h
+
+.PHONY: clean
+clean:
+	rm -f app.bin app.elf $(OBJS)
+
+# Uses ../.clang-format
+FMTFILES=*.[ch]
+
+.PHONY: fmt
+fmt:
+	clang-format --dry-run --ferror-limit=0 $(FMTFILES)
+	clang-format --verbose -i $(FMTFILES)
+.PHONY: checkfmt
+checkfmt:
+	clang-format --dry-run --ferror-limit=0 --Werror $(FMTFILES)

--- a/apps/usb_echo/main.c
+++ b/apps/usb_echo/main.c
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <tkey/assert.h>
-#include <tkey/led.h>
 #include <tkey/io.h>
+#include <tkey/led.h>
 #include <tkey/tk1_mem.h>
 
 #define FORWARD_TO_DEBUG_HID 0
@@ -34,7 +34,6 @@ int main(void)
 	*cpu_mon_first = *app_addr + *app_size;
 	*cpu_mon_last = TK1_RAM_BASE + TK1_RAM_SIZE;
 	*cpu_mon_ctrl = 1;
-
 
 	for (;;) {
 		led_set(led_color);

--- a/apps/usb_echo/main.c
+++ b/apps/usb_echo/main.c
@@ -3,14 +3,15 @@
 
 #include <tkey/assert.h>
 #include <tkey/led.h>
-#include <tkey/proto.h>
+#include <tkey/io.h>
 #include <tkey/tk1_mem.h>
 
-#define MODE_TKEYCTRL 0x20
-#define MODE_CDC 0x40
-#define MODE_HID 0x80
-
 #define FORWARD_TO_DEBUG_HID 0
+#if FORWARD_TO_DEBUG_HID
+#define ENABLED_EPS (IO_CDC | IO_FIDO | IO_DEBUG)
+#else
+#define ENABLED_EPS (IO_CDC | IO_FIDO)
+#endif
 
 // clang-format off
 static volatile uint32_t *cpu_mon_ctrl  = (volatile uint32_t *) TK1_MMIO_TK1_CPU_MON_CTRL;
@@ -22,9 +23,11 @@ static volatile uint32_t *app_size      = (volatile uint32_t *) TK1_MMIO_TK1_APP
 
 int main(void)
 {
-	uint8_t mode = 0;
+	enum ioend ep = 0;
 	uint8_t len = 0;
 	uint8_t data[256];
+
+	config_endpoints(ENABLED_EPS);
 
 	// Use Execution Monitor on RAM after app
 	*cpu_mon_first = *app_addr + *app_size;
@@ -34,36 +37,18 @@ int main(void)
 	led_set(LED_BLUE);
 
 	for (;;) {
-		mode = readbyte();
-		len = readbyte();
 
-		for (int i = 0; i < len; i++) {
-			data[i] = readbyte();
 		}
 
-		switch (mode) {
-		case MODE_CDC:
-			break;
-		case MODE_HID:
-			break;
-		default:
-			assert(1 == 2);
-		}
+		readselect(IO_CDC | IO_FIDO, &ep, &len);
+		read(ep, data, sizeof(data), len);
 
 		// Echo data
-		writebyte(mode);
-		writebyte(len);
-		for (int i = 0; i < len; i++) {
-			writebyte(data[i]);
-		}
+		write(ep, data, len);
 
 #if FORWARD_TO_DEBUG_HID
 		// Write data to debug end point
-		writebyte(MODE_TKEYCTRL);
-		writebyte(len);
-		for (int i = 0; i < len; i++) {
-			writebyte(data[i]);
-		}
+		write(IO_DEBUG, data, len);
 #endif
 	}
 }

--- a/apps/usb_echo/main.c
+++ b/apps/usb_echo/main.c
@@ -26,6 +26,7 @@ int main(void)
 	enum ioend ep = 0;
 	uint8_t len = 0;
 	uint8_t data[256];
+	uint8_t led_color = LED_BLUE;
 
 	config_endpoints(ENABLED_EPS);
 
@@ -34,10 +35,14 @@ int main(void)
 	*cpu_mon_last = TK1_RAM_BASE + TK1_RAM_SIZE;
 	*cpu_mon_ctrl = 1;
 
-	led_set(LED_BLUE);
 
 	for (;;) {
+		led_set(led_color);
 
+		if (led_color != LED_BLUE) {
+			led_color = LED_BLUE;
+		} else {
+			led_color = LED_RED;
 		}
 
 		readselect(IO_CDC | IO_FIDO, &ep, &len);

--- a/apps/usb_echo/main.c
+++ b/apps/usb_echo/main.c
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2022 Tillitis AB <tillitis.se>
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <tkey/assert.h>
+#include <tkey/led.h>
+#include <tkey/proto.h>
+#include <tkey/tk1_mem.h>
+
+#define MODE_TKEYCTRL 0x20
+#define MODE_CDC 0x40
+#define MODE_HID 0x80
+
+#define FORWARD_TO_DEBUG_HID 0
+
+// clang-format off
+static volatile uint32_t *cpu_mon_ctrl  = (volatile uint32_t *) TK1_MMIO_TK1_CPU_MON_CTRL;
+static volatile uint32_t *cpu_mon_first = (volatile uint32_t *) TK1_MMIO_TK1_CPU_MON_FIRST;
+static volatile uint32_t *cpu_mon_last  = (volatile uint32_t *) TK1_MMIO_TK1_CPU_MON_LAST;
+static volatile uint32_t *app_addr      = (volatile uint32_t *) TK1_MMIO_TK1_APP_ADDR;
+static volatile uint32_t *app_size      = (volatile uint32_t *) TK1_MMIO_TK1_APP_SIZE;
+// clang-format on
+
+int main(void)
+{
+	uint8_t mode = 0;
+	uint8_t len = 0;
+	uint8_t data[256];
+
+	// Use Execution Monitor on RAM after app
+	*cpu_mon_first = *app_addr + *app_size;
+	*cpu_mon_last = TK1_RAM_BASE + TK1_RAM_SIZE;
+	*cpu_mon_ctrl = 1;
+
+	led_set(LED_BLUE);
+
+	for (;;) {
+		mode = readbyte();
+		len = readbyte();
+
+		for (int i = 0; i < len; i++) {
+			data[i] = readbyte();
+		}
+
+		switch (mode) {
+		case MODE_CDC:
+			break;
+		case MODE_HID:
+			break;
+		default:
+			assert(1 == 2);
+		}
+
+		// Echo data
+		writebyte(mode);
+		writebyte(len);
+		for (int i = 0; i < len; i++) {
+			writebyte(data[i]);
+		}
+
+#if FORWARD_TO_DEBUG_HID
+		// Write data to debug end point
+		writebyte(MODE_TKEYCTRL);
+		writebyte(len);
+		for (int i = 0; i < len; i++) {
+			writebyte(data[i]);
+		}
+#endif
+	}
+}

--- a/tools/spdx-ensure
+++ b/tools/spdx-ensure
@@ -36,6 +36,7 @@ apps/rng_stream/Makefile
 apps/timer/Makefile
 apps/touch/Makefile
 apps/signbench/Makefile
+apps/usb_echo/Makefile
 build.sh
 go.mod
 go.sum


### PR DESCRIPTION
## Description
Add USB echo app.

Received data will be echoed back to the client. The app assumes that the USB controller support the multi-endpoint USB controller protocol.

## Type of change

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
