### PR TITLE
Touch test update. 

### DIFF
--- a/apps/touch/main.c
+++ b/apps/touch/main.c
@@ -12,6 +12,7 @@ static volatile uint32_t *touch = (volatile uint32_t *)TK1_MMIO_TOUCH_STATUS;
 #define LED_RED   (1 << TK1_MMIO_TK1_LED_R_BIT)
 #define LED_GREEN (1 << TK1_MMIO_TK1_LED_G_BIT)
 #define LED_BLUE  (1 << TK1_MMIO_TK1_LED_B_BIT)
+#define LED_WHITE (LED_RED | LED_GREEN | LED_BLUE)
 // clang-format on
 
 void wait_touch_ledflash(int ledvalue, int loopcount)
@@ -36,11 +37,14 @@ touched:
 int main(void)
 {
 
+	// Start blinking white when app is loaded.
+	wait_touch_ledflash(LED_WHITE, 350000);
+
 	for (;;) {
 		// Wait for a touch, confirming a successful touch by
 		// waiting with a new color. Continuing indefinitely.
-		wait_touch_ledflash(LED_GREEN, 350000);
 		wait_touch_ledflash(LED_RED, 350000);
+		wait_touch_ledflash(LED_GREEN, 350000);
 		wait_touch_ledflash(LED_BLUE, 350000);
 	}
 }


### PR DESCRIPTION
## Description

Status LED blink to start with white color when app is loaded and ready. 
Then change color on status LED on every registred touch. Color blink order: R-G-B-... indefinitely.

Fixes # (issues)
N/A

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
